### PR TITLE
Feature: Role-Based Username Detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ using a curated list of popular services.
 
 List used: [Github gist](https://gist.github.com/okutbay/5b4974b70673dfdcc21c517632c1f984) by @okutbay 
 
+### 7. **Role-Based Username Detection**
+Detects generic or departmental username (e.g. `info@`, `admin@`, `support@`) by checking against a curated list of common role-based usernames.
+
+List used: https://github.com/mbalatsko/role-based-email-addresses-list (original repo: https://github.com/mixmaxhq/role-based-email-addresses)
 
 ## 🧪 Output: Validation Results
 
@@ -60,7 +64,8 @@ data class EmailValidationResult(
     val mxRecordCheck: CheckResult,
     val disposabilityCheck: CheckResult,
     val gravatarCheck: CheckResult,
-    val freeCheck: CheckResult
+    val freeCheck: CheckResult,
+    val roleBasedUsernameCheck: CheckResult
 ) {
   /**
    * Returns true if all strong indicator checks either passed or were skipped.
@@ -132,8 +137,6 @@ val verifier = EmailVerifier.init(config)
 ## 🔮 Roadmap
 Planned features:
 
-* **Role-Based Username Detection** 
-  * Flag addresses like `info@`, `admin@`, `support@` that are not person-specific
 * **Typo check** suggestions
 * **SMTP Probing**
   * Connect to the target mail server and verify deliverability via the `RCPT TO` SMTP command (without sending email)

--- a/src/main/kotlin/io/github/mbalatsko/emailverifier/components/checkers/DisposableEmailChecker.kt
+++ b/src/main/kotlin/io/github/mbalatsko/emailverifier/components/checkers/DisposableEmailChecker.kt
@@ -19,7 +19,7 @@ class DisposableEmailChecker(
      * Must be called before using [isDisposable].
      */
     suspend fun loadData() {
-        disposableDomainsSet = domainsProvider.provide().toSet()
+        disposableDomainsSet = domainsProvider.provide()
     }
 
     /**

--- a/src/main/kotlin/io/github/mbalatsko/emailverifier/components/checkers/FreeChecker.kt
+++ b/src/main/kotlin/io/github/mbalatsko/emailverifier/components/checkers/FreeChecker.kt
@@ -8,12 +8,12 @@ import io.github.mbalatsko.emailverifier.components.providers.DomainsProvider
  * Loads a list of free email domains (e.g., gmail.com, yahoo.com) from a
  * [DomainsProvider] and allows rapid membership queries.
  *
- * @property domainsProvider source of newline-separated domain names.
+ * @property domainsProvider source of domain names.
  */
 class FreeChecker(
     val domainsProvider: DomainsProvider,
 ) {
-    private var disposableDomainsSet = emptySet<String>()
+    private var freeDomainsSet = emptySet<String>()
 
     /**
      * Loads and indexes the free-email domain list from the [domainsProvider].
@@ -21,7 +21,7 @@ class FreeChecker(
      * Must be called before invoking [isFree].
      */
     suspend fun loadData() {
-        disposableDomainsSet = domainsProvider.provide().toSet()
+        freeDomainsSet = domainsProvider.provide()
     }
 
     /**
@@ -30,7 +30,7 @@ class FreeChecker(
      * @param hostname the domain part of an email address.
      * @return `true` if the domain is recognized as a free-email provider.
      */
-    fun isFree(hostname: String): Boolean = hostname in disposableDomainsSet
+    fun isFree(hostname: String): Boolean = hostname in freeDomainsSet
 
     companion object {
         /**

--- a/src/main/kotlin/io/github/mbalatsko/emailverifier/components/checkers/RoleBasedUsernameChecker.kt
+++ b/src/main/kotlin/io/github/mbalatsko/emailverifier/components/checkers/RoleBasedUsernameChecker.kt
@@ -1,0 +1,55 @@
+package io.github.mbalatsko.emailverifier.components.checkers
+
+import io.github.mbalatsko.emailverifier.components.providers.DomainsProvider
+
+/**
+ * Checks whether a given username is a role-based address (e.g., `info`, `admin`, `support`).
+ *
+ * Loads a curated list of known role-based local-parts from a [DomainsProvider]
+ * and allows rapid membership queries.
+ *
+ * @property domainsProvider source of role-based usernames.
+ */
+class RoleBasedUsernameChecker(
+    val domainsProvider: DomainsProvider,
+) {
+    private var roleBasedUsernamesSet = emptySet<String>()
+
+    /**
+     * Loads and indexes the role-based username list from the [domainsProvider].
+     *
+     * Must be called before invoking [isRoleBased].
+     */
+    suspend fun loadData() {
+        roleBasedUsernamesSet = domainsProvider.provide()
+    }
+
+    /**
+     * Determines if the specified username is recognized as role-based.
+     *
+     * @param username the username of an email address.
+     * @return `true` if the username is in the role-based list.
+     */
+    fun isRoleBased(username: String): Boolean = username in roleBasedUsernamesSet
+
+    companion object {
+        /**
+         * URL pointing to a text file of common role-based usernames.
+         */
+        const val ROLE_BASED_USERNAMES_LIST_URL =
+            "https://raw.githubusercontent.com/mbalatsko/role-based-email-addresses-list/main/list.txt"
+
+        /**
+         * Convenience initializer that creates a [RoleBasedUsernameChecker] and immediately
+         * loads its username data.
+         *
+         * @param domainsProvider the provider for role-based usernames.
+         * @return an initialized [RoleBasedUsernameChecker].
+         */
+        suspend fun init(domainsProvider: DomainsProvider): RoleBasedUsernameChecker {
+            val roleBasedUsernameChecker = RoleBasedUsernameChecker(domainsProvider)
+            roleBasedUsernameChecker.loadData()
+            return roleBasedUsernameChecker
+        }
+    }
+}

--- a/src/main/kotlin/io/github/mbalatsko/emailverifier/components/providers/DomainsProviders.kt
+++ b/src/main/kotlin/io/github/mbalatsko/emailverifier/components/providers/DomainsProviders.kt
@@ -7,15 +7,15 @@ import io.ktor.client.statement.bodyAsText
 import java.net.IDN
 
 /**
- * Interface for providing a list of domain names.
+ * Interface for providing a set of domain names.
  */
 interface DomainsProvider {
     /**
      * Retrieves a list of domain names.
      *
-     * @return a list of ASCII-compatible domain names.
+     * @return a set of ASCII-compatible domain names.
      */
-    suspend fun provide(): List<String>
+    suspend fun provide(): Set<String>
 }
 
 /**
@@ -31,12 +31,12 @@ abstract class LFDomainsProvider : DomainsProvider {
      */
     abstract suspend fun obtainData(): String
 
-    override suspend fun provide(): List<String> =
+    override suspend fun provide(): Set<String> =
         obtainData()
             .lineSequence()
             .filter { it.isNotEmpty() && !it.startsWith("//") }
             .map { IDN.toASCII(it.trim().lowercase()) }
-            .toList()
+            .toSet()
 }
 
 /**

--- a/src/test/kotlin/io/github/mbalatsko/emailverifier/components/checkers/DisposableEmailCheckerTest.kt
+++ b/src/test/kotlin/io/github/mbalatsko/emailverifier/components/checkers/DisposableEmailCheckerTest.kt
@@ -8,13 +8,13 @@ import kotlin.test.assertTrue
 
 class DisposableEmailCheckerTest {
     private class TestDomainsProvider(
-        private val domains: List<String>,
+        private val domains: Set<String>,
     ) : DomainsProvider {
-        override suspend fun provide(): List<String> = domains
+        override suspend fun provide(): Set<String> = domains
     }
 
     private val testDomains =
-        listOf(
+        setOf(
             "temp-mail.org",
             "mailinator.com",
             "disposable.co",

--- a/src/test/kotlin/io/github/mbalatsko/emailverifier/components/checkers/PslIndexTest.kt
+++ b/src/test/kotlin/io/github/mbalatsko/emailverifier/components/checkers/PslIndexTest.kt
@@ -8,15 +8,15 @@ import kotlin.test.assertTrue
 
 class PslIndexTest {
     private class TestDomainsProvider(
-        private val rules: List<String>,
+        private val rules: Set<String>,
     ) : DomainsProvider {
-        override suspend fun provide(): List<String> = rules
+        override suspend fun provide(): Set<String> = rules
     }
 
     @Test
     fun `basic registrability with simple suffix rules`() =
         runTest {
-            val rules = listOf("com", "co.uk")
+            val rules = setOf("com", "co.uk")
             val psl = PslIndex(TestDomainsProvider(rules))
             psl.build()
 
@@ -30,7 +30,7 @@ class PslIndexTest {
     @Test
     fun `wildcard rules block second-level but allow deeper domains`() =
         runTest {
-            val rules = listOf("*.ck")
+            val rules = setOf("*.ck")
             val psl = PslIndex(TestDomainsProvider(rules))
             psl.build()
 
@@ -41,7 +41,7 @@ class PslIndexTest {
     @Test
     fun `exception rules override suffix rules`() =
         runTest {
-            val rules = listOf("*.ck", "!pref.ck")
+            val rules = setOf("*.ck", "!pref.ck")
             val psl = PslIndex(TestDomainsProvider(rules))
             psl.build()
 
@@ -55,7 +55,7 @@ class PslIndexTest {
     @Test
     fun `no match means non-registrable`() =
         runTest {
-            val rules = listOf("net")
+            val rules = setOf("net")
             val psl = PslIndex(TestDomainsProvider(rules))
             psl.build()
 

--- a/src/test/kotlin/io/github/mbalatsko/emailverifier/components/providers/DomainProvidersTest.kt
+++ b/src/test/kotlin/io/github/mbalatsko/emailverifier/components/providers/DomainProvidersTest.kt
@@ -30,7 +30,7 @@ class DomainProvidersTest {
             val result = provider.provide()
 
             assertEquals(
-                listOf("example.com", "example.org", "xn--bcher-kva.de"),
+                setOf("example.com", "example.org", "xn--bcher-kva.de"),
                 result,
             )
         }
@@ -47,6 +47,6 @@ class DomainProvidersTest {
             val provider = OnlineLFDomainsProvider("https://mock.url", client)
 
             val result = provider.provide()
-            assertEquals(listOf("disposable.com", "trashmail.org"), result)
+            assertEquals(setOf("disposable.com", "trashmail.org"), result)
         }
 }


### PR DESCRIPTION
Detects generic or departmental username (e.g. `info@`, `admin@`, `support@`) by checking against a curated list of common role-based usernames.

List used: https://github.com/mbalatsko/role-based-email-addresses-list (original repo: https://github.com/mixmaxhq/role-based-email-addresses)

Also changed `DomainProvider` to return `Set` instead of `List`