### PR TITLE
feat: Add SMTP Deliverability Check

### DIFF
--- a/src/main/kotlin/io/github/mbalatsko/emailverifier/components/checkers/SmtpChecker.kt
+++ b/src/main/kotlin/io/github/mbalatsko/emailverifier/components/checkers/SmtpChecker.kt
@@ -1,0 +1,192 @@
+package io.github.mbalatsko.emailverifier.components.checkers
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.IOException
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.InetSocketAddress
+import java.net.Proxy
+import java.net.Socket
+import kotlin.random.Random
+
+/**
+ * Represents a response from an SMTP server.
+ *
+ * @property code The 3-digit SMTP response code.
+ * @property msg The response message.
+ */
+data class SmtpResponse(
+    val code: Int,
+    val msg: String,
+)
+
+/**
+ * An interface for an SMTP connection, abstracting the underlying socket communication.
+ */
+interface ISmtpConnection {
+    /**
+     * Sends a command to the SMTP server.
+     *
+     * @param cmd The command string to send.
+     * @return The server's [SmtpResponse].
+     */
+    fun sendCommand(cmd: String): SmtpResponse
+
+    /**
+     * Closes the connection to the SMTP server.
+     */
+    fun close()
+}
+
+/**
+ * A concrete implementation of [ISmtpConnection] using a [java.net.Socket].
+ *
+ * @property socket The underlying socket for the connection.
+ * @property reader The buffered reader for receiving server responses.
+ * @property writer The buffered writer for sending commands.
+ *
+ * @param address The server address to connect to.
+ * @param port The server port to connect to.
+ * @param timeoutMillis The connection and read timeout in milliseconds.
+ * @param proxy The proxy to use for the connection, or null for a direct connection.
+ */
+class SocketSmtpConnection(
+    address: String,
+    port: Int,
+    timeoutMillis: Int,
+    proxy: Proxy?,
+) : ISmtpConnection {
+    val socket = if (proxy != null) Socket(proxy) else Socket()
+    var reader: BufferedReader
+    var writer: BufferedWriter
+
+    init {
+        socket.connect(InetSocketAddress(address, port), timeoutMillis)
+        socket.soTimeout = timeoutMillis
+
+        reader = BufferedReader(InputStreamReader(socket.getInputStream()))
+        writer = BufferedWriter(OutputStreamWriter(socket.getOutputStream()))
+
+        val resp = readResponse()
+        require(resp.code == 220) { "Server did not respond with 220 code, ${resp.code} got instead" }
+    }
+
+    private fun readResponse(): SmtpResponse {
+        val line = reader.readLine() ?: return SmtpResponse(0, "")
+        val code = line.take(3).toIntOrNull() ?: 0
+        return SmtpResponse(code, line)
+    }
+
+    override fun sendCommand(cmd: String): SmtpResponse {
+        writer.write("$cmd\r\n")
+        writer.flush()
+        return readResponse()
+    }
+
+    override fun close() {
+        socket.close()
+    }
+}
+
+/**
+ * A factory for creating [ISmtpConnection] instances.
+ */
+fun interface SmtpConnectionFactory {
+    /**
+     * Creates and connects an [ISmtpConnection].
+     *
+     * @param address The server address to connect to.
+     * @param port The server port to connect to.
+     * @return An initialized [ISmtpConnection].
+     */
+    fun connect(
+        address: String,
+        port: Int,
+    ): ISmtpConnection
+}
+
+/**
+ * Data class holding the results of an SMTP check.
+ *
+ * @property isDeliverable true if the email address is deliverable.
+
+ * @property isCatchAll true if the server has a catch-all policy, false if not, null if inconclusive.
+ * @property smtpCode the last SMTP response code.
+ * @property smtpMessage the last SMTP response message.
+ */
+data class SmtpData(
+    val isDeliverable: Boolean,
+    val isCatchAll: Boolean?,
+    val smtpCode: Int,
+    val smtpMessage: String,
+)
+
+/**
+ * Performs an SMTP check to verify if an email address is deliverable.
+ *
+ * @property enableAllCatchCheck whether to check if the server has a catch-all policy.
+ * @property maxRetries maximum number of retries for SMTP commands.
+ */
+class SmtpChecker(
+    private val enableAllCatchCheck: Boolean,
+    private val maxRetries: Int,
+    private val smtpConnectionFactory: SmtpConnectionFactory,
+) {
+    /**
+     * Verifies an email address by connecting to the mail server and simulating sending an email.
+     *
+     * @param email the email address to verify.
+     * @param mxRecords a list of MX records for the domain.
+     * @return an [SmtpData] object with the verification results.
+     */
+    fun verifyEmail(
+        email: EmailParts,
+        mxRecords: List<MxRecord>,
+    ): SmtpData {
+        if (mxRecords.isEmpty()) return SmtpData(false, null, 0, "")
+
+        val fakeLocalPart = "${Random.nextInt(10000, 99999)}catchalltest${Random.nextInt(10000, 99999)}"
+        val fakeEmail = "$fakeLocalPart@${email.hostname}"
+
+        for (mx in mxRecords) {
+            repeat(maxRetries) { attempt ->
+                try {
+                    val conn = smtpConnectionFactory.connect(mx.exchange, SMTP_PORT)
+                    conn.sendCommand("HELO $HELO_DOMAIN")
+                    conn.sendCommand("MAIL FROM:<$HELO_EMAIL>")
+                    val resp = conn.sendCommand("RCPT TO:<${email.username}@${email.hostname}>")
+
+                    val deliverable = resp.code in 200..299
+
+                    // Optional catch-all test
+                    val catchAll =
+                        if (enableAllCatchCheck) {
+                            val fakeResp = conn.sendCommand("RCPT TO:<$fakeEmail>")
+                            when (fakeResp.code) {
+                                in 200..299 -> true
+                                in 500..599 -> false
+                                else -> null // inconclusive
+                            }
+                        } else {
+                            null
+                        }
+
+                    conn.sendCommand("QUIT")
+                    conn.close()
+
+                    return SmtpData(deliverable, catchAll, resp.code, resp.msg)
+                } catch (_: IOException) {
+                }
+            }
+        }
+
+        return SmtpData(false, null, 0, "")
+    }
+
+    companion object {
+        private const val HELO_EMAIL = "check@example.com"
+        private const val HELO_DOMAIN = "example.com"
+        private const val SMTP_PORT = 25
+    }
+}

--- a/src/test/kotlin/io/github/mbalatsko/emailverifier/EmailVerifierTest.kt
+++ b/src/test/kotlin/io/github/mbalatsko/emailverifier/EmailVerifierTest.kt
@@ -37,6 +37,7 @@ class EmailVerifierLocalTest {
             gravatarChecker = null,
             freeChecker = FreeChecker.init(FixedListProvider(setOf("free.com"))),
             roleBasedUsernameChecker = RoleBasedUsernameChecker.init(FixedListProvider(setOf("role"))),
+            smtpChecker = null,
         )
 
     @Test
@@ -125,6 +126,7 @@ class EmailVerifierLocalTest {
                     gravatarChecker = null,
                     freeChecker = null,
                     roleBasedUsernameChecker = null,
+                    smtpChecker = null,
                 )
             val result = verifier.verify("user@example.com")
             assertTrue(result.mx is CheckResult.Errored)
@@ -153,7 +155,15 @@ class EmailVerifierLocalTest {
 }
 
 class EmailVerifierOnlineTest {
-    private val onlineEmailVerifier = runBlocking { emailVerifier {} }
+    private val onlineEmailVerifier =
+        runBlocking {
+            emailVerifier {
+                smtp {
+                    enabled = true
+                    maxRetries = 1
+                }
+            }
+        }
 
     @Test
     fun `gmail passes main checks but fails free and gravatar`() =
@@ -163,6 +173,7 @@ class EmailVerifierOnlineTest {
             assertTrue(result.gravatar is CheckResult.Failed<*>)
             assertTrue(result.free is CheckResult.Failed<*>)
             assertTrue(result.roleBasedUsername is CheckResult.Passed<*>)
+            assertTrue(result.smtp is CheckResult.Passed)
         }
 
     @Test
@@ -224,6 +235,7 @@ class EmailVerifierOfflineTest {
 
             assertTrue(result.gravatar is CheckResult.Skipped)
             assertTrue(result.mx is CheckResult.Skipped)
+            assertTrue(result.smtp is CheckResult.Skipped)
         }
 
     @Test

--- a/src/test/kotlin/io/github/mbalatsko/emailverifier/components/checkers/SmtpCheckerTest.kt
+++ b/src/test/kotlin/io/github/mbalatsko/emailverifier/components/checkers/SmtpCheckerTest.kt
@@ -1,0 +1,175 @@
+package io.github.mbalatsko.emailverifier.components.checkers
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SmtpCheckerTest {
+    @Test
+    fun `verifyEmail returns deliverable when RCPT TO is successful`() =
+        runTest {
+            // Arrange
+            val mockConnection = MockSmtpConnection()
+            val mockConnectionFactory = SmtpConnectionFactory { _, _ -> mockConnection }
+
+            // Simulate the SMTP conversation
+            mockConnection.addResponse(250, "OK") // HELO
+            mockConnection.addResponse(250, "OK") // MAIL FROM
+            mockConnection.addResponse(250, "OK, user exists") // RCPT TO
+            mockConnection.addResponse(221, "Bye") // QUIT
+
+            val checker =
+                SmtpChecker(
+                    enableAllCatchCheck = false,
+                    maxRetries = 1,
+                    smtpConnectionFactory = mockConnectionFactory,
+                )
+            val emailParts = EmailParts("user", "", "domain.com")
+            val mxRecords = listOf(MxRecord("mx.domain.com", 10))
+
+            // Act
+            val result = checker.verifyEmail(emailParts, mxRecords)
+
+            // Assert
+            assertTrue(result.isDeliverable)
+            assertEquals(250, result.smtpCode)
+            assertEquals("OK, user exists", result.smtpMessage)
+        }
+
+    @Test
+    fun `verifyEmail returns not deliverable when RCPT TO fails`() =
+        runTest {
+            // Arrange
+            val mockConnection = MockSmtpConnection()
+            val mockConnectionFactory = SmtpConnectionFactory { _, _ -> mockConnection }
+
+            mockConnection.addResponse(250, "OK") // HELO
+            mockConnection.addResponse(250, "OK") // MAIL FROM
+            mockConnection.addResponse(550, "No such user") // RCPT TO
+            mockConnection.addResponse(221, "Bye") // QUIT
+
+            val checker =
+                SmtpChecker(
+                    enableAllCatchCheck = false,
+                    maxRetries = 1,
+                    smtpConnectionFactory = mockConnectionFactory,
+                )
+            val emailParts = EmailParts("user", "", "domain.com")
+            val mxRecords = listOf(MxRecord("mx.domain.com", 10))
+
+            // Act
+            val result = checker.verifyEmail(emailParts, mxRecords)
+
+            // Assert
+            assertFalse(result.isDeliverable)
+            assertEquals(550, result.smtpCode)
+            assertEquals("No such user", result.smtpMessage)
+        }
+
+    @Test
+    fun `detects catch-all when enabled and fake email is accepted`() =
+        runTest {
+            // Arrange
+            val mockConnection = MockSmtpConnection()
+            val mockConnectionFactory = SmtpConnectionFactory { _, _ -> mockConnection }
+
+            mockConnection.addResponse(250, "OK") // HELO
+            mockConnection.addResponse(250, "OK") // MAIL FROM
+            mockConnection.addResponse(250, "OK, user exists") // RCPT TO (real email)
+            mockConnection.addResponse(250, "OK, accepted") // RCPT TO (fake email)
+            mockConnection.addResponse(221, "Bye") // QUIT
+
+            val checker =
+                SmtpChecker(
+                    enableAllCatchCheck = true,
+                    maxRetries = 1,
+                    smtpConnectionFactory = mockConnectionFactory,
+                )
+            val emailParts = EmailParts("user", "", "domain.com")
+            val mxRecords = listOf(MxRecord("mx.domain.com", 10))
+
+            // Act
+            val result = checker.verifyEmail(emailParts, mxRecords)
+
+            // Assert
+            assertTrue(result.isDeliverable)
+            assertTrue(result.isCatchAll == true)
+        }
+
+    @Test
+    fun `handles connection IOException and retries with next MX record`() =
+        runTest {
+            var i = 0
+            val mockConnectionFactory =
+                SmtpConnectionFactory { _, _ ->
+                    when (i) {
+                        0 -> {
+                            i++
+                            MockSmtpConnection(throwOnConnect = true)
+                        }
+                        else ->
+                            MockSmtpConnection().apply {
+                                addResponse(250, "OK") // HELO
+                                addResponse(250, "OK") // MAIL FROM
+                                addResponse(250, "OK") // RCPT TO
+                                addResponse(221, "Bye") // QUIT
+                            }
+                    }
+                }
+
+            val checker =
+                SmtpChecker(
+                    enableAllCatchCheck = false,
+                    maxRetries = 1,
+                    smtpConnectionFactory = mockConnectionFactory,
+                )
+            val emailParts = EmailParts("user", "", "domain.com")
+            val mxRecords =
+                listOf(
+                    MxRecord("mx1.domain.com", 10),
+                    MxRecord("mx2.domain.com", 20),
+                )
+
+            val result = checker.verifyEmail(emailParts, mxRecords)
+
+            assertTrue(result.isDeliverable)
+            assertEquals(250, result.smtpCode)
+        }
+}
+
+/**
+ * A simple mock implementation of ISmptConnection for testing.
+ */
+class MockSmtpConnection(
+    throwOnConnect: Boolean = false,
+) : ISmtpConnection {
+    private val responses = mutableListOf<SmtpResponse>()
+    private var connectCalled = false
+    private var closeCalled = false
+
+    init {
+        if (throwOnConnect) {
+            throw java.io.IOException("Connection failed")
+        }
+        connectCalled = true
+    }
+
+    fun addResponse(
+        code: Int,
+        msg: String,
+    ) {
+        responses.add(SmtpResponse(code, msg))
+    }
+
+    override fun sendCommand(cmd: String): SmtpResponse {
+        assertTrue(connectCalled, "connect() must be called before sendCommand()")
+        assertFalse(closeCalled, "sendCommand() should not be called after close()")
+        return responses.removeAt(0)
+    }
+
+    override fun close() {
+        closeCalled = true
+    }
+}


### PR DESCRIPTION
This PR introduces a robust SMTP check to verify if a mailbox exists on a remote server. It simulates an email delivery without sending a message, providing a high-confidence signal of an email's validity.

## Key Features:
* **Live Mailbox Verification**: Connects to the mail server via MX records and uses the RCPT TO command to confirm if a recipient is valid.
* **Catch-All Detection**: Intelligently detects if a server accepts all emails to a domain, providing a crucial piece of validation context.
* **SOCKS Proxy Support**: Crucially, allows routing the SMTP connection through a proxy. This is essential as most cloud providers (AWS, GCP) and ISPs block outbound traffic on port `25`.

## Configuration:
The feature is disabled by default due to port `25` blocking. It must be explicitly enabled in the DSL:

```kotlin
val verifier = emailVerifier {
  smtp {
    enabled = true
    // To bypass port blocking, configure a proxy:
   proxy = Proxy(Proxy.Type.SOCKS, InetSocketAddress("your-proxy.com", 1080))
  }
}
```
