### PR TITLE
feat: Add `allow/deny` list functionality to dataset checkers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Ensures the domain is actually configured to receive emails:
 Filters out **temporary/disposable** email domains:
 - Uses curated lists from [disposable-email-domains](https://github.com/disposable/disposable-email-domains)
 - Detects domains like `mailinator.com`, `tempmail.org`, etc.
+- You can also specify `allow` and `deny` sets to customize the behavior for specific domains.
 
 ### 5. **Gravatar Existence Check**
 
@@ -51,12 +52,14 @@ Detects whether an email has an associated **Gravatar**:
 Checks whether the email domain belongs to a known free‐email provider (e.g. `gmail.com`, `yahoo.com`) 
 using a curated list of popular services.
 - Returns `Passed` result if email hostname is not a known free‐email provider
+- You can also specify `allow` and `deny` sets to customize the behavior for specific domains.
 
 List used: [Github gist](https://gist.github.com/okutbay/5b4974b70673dfdcc21c517632c1f984) by @okutbay 
 
 ### 7. **Role-Based Username Detection**
 Detects generic or departmental username (e.g. `info@`, `admin@`, `support@`) by checking against a curated list of common role-based usernames.
 - Returns `Passed` result if email username is not a known role-based username
+- You can also specify `allow` and `deny` sets to customize the behavior for specific usernames.
 
 List used: https://github.com/mbalatsko/role-based-email-addresses-list (original repo: https://github.com/mixmaxhq/role-based-email-addresses)
 
@@ -179,10 +182,12 @@ data class GravatarData(
  *
  * @property match true if a match was found in the dataset.
  * @property matchedOn the specific entry that was matched, or null if no match was found.
+ * @property source the source of the match (e.g., "allow", "deny", "default").
  */
 data class DatasetData(
     val match: Boolean,
     val matchedOn: String? = null,
+    val source: Source? = null,
 )
 
 /**
@@ -263,6 +268,8 @@ val verifier = emailVerifier {
     disposability {
         enabled = true // Explicitly enable (default is true)
         domainsListUrl = "https://my.custom.domain/disposable_domains.txt" // Custom disposable domains list
+        allow = setOf("my-disposable-domain.com") // Whitelist a disposable domain
+        deny = setOf("my-domain.com") // Blacklist a domain
     }
     gravatar {
         enabled = true // Explicitly enable (default is true)
@@ -270,10 +277,14 @@ val verifier = emailVerifier {
     free {
         enabled = false // Disable free email provider checks
         // domainsListUrl = "https://my.custom.domain/free_emails.txt" // Custom free emails list if enabled
+        allow = setOf("gmail.com") // Whitelist a free email provider
+        deny = setOf("my-free-domain.com") // Blacklist a domain
     }
     roleBasedUsername {
         enabled = true // Explicitly enable (default is true)
         usernamesListUrl = "https://my.custom.domain/role_based_usernames.txt" // Custom role-based usernames list
+        allow = setOf("admin") // Whitelist a role-based username
+        deny = setOf("my-username") // Blacklist a username
     }
     smtp {
         enabled = true // IMPORTANT: Disabled by default. See notes below.

--- a/src/main/kotlin/io/github/mbalatsko/emailverifier/EmailVerifierDsl.kt
+++ b/src/main/kotlin/io/github/mbalatsko/emailverifier/EmailVerifierDsl.kt
@@ -78,11 +78,15 @@ class MxRecordConfigBuilder {
  * @property enabled whether this check should be performed.
  * @property domainsListUrl URL to the disposable email domains list.
  * @property offline whether to use the bundled offline disposable email domains list.
+ * @property allow a set of domains to be treated as not disposable.
+ * @property deny a set of domains to be treated as disposable.
  */
 data class DisposabilityConfig(
     val enabled: Boolean,
     val domainsListUrl: String,
     val offline: Boolean,
+    val allow: Set<String>,
+    val deny: Set<String>,
 )
 
 /**
@@ -98,7 +102,13 @@ class DisposabilityConfigBuilder {
     /** Whether to use the bundled offline disposable email domains list. */
     var offline: Boolean = false
 
-    internal fun build() = DisposabilityConfig(enabled, domainsListUrl, offline)
+    /** A set of domains to be treated as not disposable. */
+    var allow: Set<String> = emptySet()
+
+    /** A set of domains to be treated as disposable. */
+    var deny: Set<String> = emptySet()
+
+    internal fun build() = DisposabilityConfig(enabled, domainsListUrl, offline, allow, deny)
 }
 
 /**
@@ -126,11 +136,15 @@ class GravatarConfigBuilder {
  * @property enabled whether this check should be performed.
  * @property domainsListUrl URL to the free email provider domains list.
  * @property offline whether to use the bundled offline free email provider domains list.
+ * @property allow a set of domains to be treated as not free.
+ * @property deny a set of domains to be treated as free.
  */
 data class FreeConfig(
     val enabled: Boolean,
     val domainsListUrl: String,
     val offline: Boolean,
+    val allow: Set<String>,
+    val deny: Set<String>,
 )
 
 /**
@@ -146,7 +160,13 @@ class FreeConfigBuilder {
     /** Whether to use the bundled offline free email provider domains list. */
     var offline: Boolean = false
 
-    internal fun build() = FreeConfig(enabled, domainsListUrl, offline)
+    /** A set of domains to be treated as not free. */
+    var allow: Set<String> = emptySet()
+
+    /** A set of domains to be treated as free. */
+    var deny: Set<String> = emptySet()
+
+    internal fun build() = FreeConfig(enabled, domainsListUrl, offline, allow, deny)
 }
 
 /**
@@ -155,11 +175,15 @@ class FreeConfigBuilder {
  * @property enabled whether this check should be performed.
  * @property usernamesListUrl URL to the role-based usernames list.
  * @property offline whether to use the bundled offline role-based usernames list.
+ * @property allow a set of usernames to be treated as not role-based.
+ * @property deny a set of usernames to be treated as role-based.
  */
 data class RoleBasedUsernameConfig(
     val enabled: Boolean,
     val usernamesListUrl: String,
     val offline: Boolean,
+    val allow: Set<String>,
+    val deny: Set<String>,
 )
 
 /**
@@ -175,7 +199,13 @@ class RoleBasedUsernameConfigBuilder {
     /** Whether to use the bundled offline role-based usernames list. */
     var offline: Boolean = false
 
-    internal fun build() = RoleBasedUsernameConfig(enabled, usernamesListUrl, offline)
+    /** A set of usernames to be treated as not role-based. */
+    var allow: Set<String> = emptySet()
+
+    /** A set of usernames to be treated as role-based. */
+    var deny: Set<String> = emptySet()
+
+    internal fun build() = RoleBasedUsernameConfig(enabled, usernamesListUrl, offline, allow, deny)
 }
 
 /**
@@ -383,7 +413,7 @@ class EmailVerifierDslBuilder {
             } else {
                 OnlineLFDomainsProvider(config.domainsListUrl, httpClient)
             }
-        HostnameInDatasetChecker.create(provider)
+        HostnameInDatasetChecker.create(provider, config.allow, config.deny)
     } else {
         null
     }
@@ -405,7 +435,7 @@ class EmailVerifierDslBuilder {
             } else {
                 OnlineLFDomainsProvider(config.domainsListUrl, httpClient)
             }
-        HostnameInDatasetChecker.create(provider)
+        HostnameInDatasetChecker.create(provider, config.allow, config.deny)
     } else {
         null
     }
@@ -427,7 +457,7 @@ class EmailVerifierDslBuilder {
             } else {
                 OnlineLFDomainsProvider(config.usernamesListUrl, httpClient)
             }
-        UsernameInDatasetChecker.create(provider)
+        UsernameInDatasetChecker.create(provider, config.allow, config.deny)
     } else {
         null
     }

--- a/src/test/kotlin/io/github/mbalatsko/emailverifier/components/checkers/UsernameInDatasetCheckerTest.kt
+++ b/src/test/kotlin/io/github/mbalatsko/emailverifier/components/checkers/UsernameInDatasetCheckerTest.kt
@@ -21,6 +21,8 @@ class UsernameInDatasetCheckerTest {
         runBlocking {
             UsernameInDatasetChecker.create(
                 TestDomainsProvider(setOf("admin", "support")),
+                emptySet(),
+                emptySet(),
             )
         }
 
@@ -32,10 +34,12 @@ class UsernameInDatasetCheckerTest {
             var result = testChecker.check(testEmail.copy(username = "admin"), Unit)
             assertTrue(result.match)
             assertEquals("admin", result.matchedOn)
+            assertEquals(Source.DEFAULT, result.source)
 
             result = testChecker.check(testEmail.copy(username = "support"), Unit)
             assertTrue(result.match)
             assertEquals("support", result.matchedOn)
+            assertEquals(Source.DEFAULT, result.source)
         }
 
     @Test
@@ -44,5 +48,51 @@ class UsernameInDatasetCheckerTest {
             val result = testChecker.check(testEmail.copy(username = "john.doe"), Unit)
             assertFalse(result.match)
             assertNull(result.matchedOn)
+            assertNull(result.source)
+        }
+
+    @Test
+    fun `check returns false for allowed usernames`() =
+        runTest {
+            val checker =
+                UsernameInDatasetChecker.create(
+                    TestDomainsProvider(setOf("admin", "support")),
+                    allowSet = setOf("admin"),
+                    denySet = emptySet(),
+                )
+            val result = checker.check(testEmail.copy(username = "admin"), Unit)
+            assertFalse(result.match)
+            assertEquals("admin", result.matchedOn)
+            assertEquals(Source.ALLOW, result.source)
+        }
+
+    @Test
+    fun `check returns true for denied usernames`() =
+        runTest {
+            val checker =
+                UsernameInDatasetChecker.create(
+                    TestDomainsProvider(setOf("admin", "support")),
+                    allowSet = emptySet(),
+                    denySet = setOf("john.doe"),
+                )
+            val result = checker.check(testEmail.copy(username = "john.doe"), Unit)
+            assertTrue(result.match)
+            assertEquals("john.doe", result.matchedOn)
+            assertEquals(Source.DENY, result.source)
+        }
+
+    @Test
+    fun `allow set has priority over deny set`() =
+        runTest {
+            val checker =
+                UsernameInDatasetChecker.create(
+                    TestDomainsProvider(setOf("admin", "support")),
+                    allowSet = setOf("admin"),
+                    denySet = setOf("admin"),
+                )
+            val result = checker.check(testEmail.copy(username = "admin"), Unit)
+            assertFalse(result.match)
+            assertEquals("admin", result.matchedOn)
+            assertEquals(Source.ALLOW, result.source)
         }
 }


### PR DESCRIPTION
This PR introduces the ability to specify allow and deny lists for disposable, free, and role-based username checks.
- added `allow` and `deny` sets to `DisposabilityConfig`, `FreeConfig`, and `RoleBasedUsernameConfig` in the DSL, allowing users to customize domain/username behavior.
- Implemented logic in `HostnameInDatasetChecker` and `UsernameInDatasetChecker` to prioritize `allow` list entries over `deny` list entries, and `deny` list entries over the default dataset.
- Introduced a `Source` enum and added a `source` property to `DatasetData` to indicate whether a match originated from an allow list, deny list, or the default dataset.