### PR TITLE
feat: Add support for custom file-based data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,6 @@ val verifier = emailVerifier {
     registrability {
         enabled = true // Explicitly enable (default is true)
         pslUrl  = "https://my.custom.domain/public_suffix_list.dat" // Custom PSL URL
-        offline = false // Use online data for this check
     }
     mxRecord {
         enabled = false // Disable MX record checks
@@ -332,12 +331,12 @@ val result = verifier.verify("mbalatsko@gmail.com")
 // result.smtp will be SKIPPED
 ```
 
-You can also configure offline mode for each check individually.
+You can also configure offline mode for each check individually. When `offline` is set to `true` for a specific check, the verifier will use the bundled data by default. You can override this by providing a custom data source (see [Using Custom Data Sources](#5-using-custom-data-sources)).
 
 ```kotlin
 val verifier = emailVerifier {
     registrability {
-        offline = true // Use offline data for this check
+        offline = true // Use bundled offline data for this check
     }
     disposability {
         offline = true
@@ -346,7 +345,43 @@ val verifier = emailVerifier {
 }
 ```
 
-### 5. Advanced Configuration: Custom HttpClient
+### 5. Using Custom Data Sources
+
+For checks that rely on external datasets (Registrability, Disposability, Free Email, and Role-Based Username), you can override the default data sources by providing your own files. This is useful for testing, working with proprietary lists, or when you need to manage datasets locally.
+
+You can provide a file from your project's **resources** or from the local **filesystem**.
+
+#### From Classpath Resources
+
+Place your data file (e.g., `my_disposable_domains.txt`) in your project's `src/main/resources` directory. Then, configure the verifier to use it by setting the `resourcesFilePath` property.
+
+```kotlin
+val verifier = emailVerifier {
+    disposability {
+        offline = true // Required when using custom file-based sources
+        resourcesFilePath = "/my_disposable_domains.txt"
+    }
+    // You can do the same for registrability, free, and roleBasedUsername checks
+}
+```
+
+#### From the Filesystem
+
+You can also load a data file from any path on the local filesystem using the `filePath` property.
+
+```kotlin
+val verifier = emailVerifier {
+    disposability {
+        offline = true // Required when using custom file-based sources
+        filePath = "/path/to/your/disposable_domains.txt"
+    }
+}
+```
+
+> **Note:** When using `resourcesFilePath` or `filePath`, you must set `offline = true` for that specific check. This tells the verifier to use local data providers instead of fetching data from the network. Note that `resourcesFilePath` and `filePath` cannot be set at the same time.
+
+
+### 6. Advanced Configuration: Custom HttpClient
 
 The default `HttpClient` used by `EmailVerifier` is configured with a sensible retry policy (`retryOnServerErrors(maxRetries = 3)` with exponential backoff) to handle transient network issues.
 

--- a/src/main/kotlin/io/github/mbalatsko/emailverifier/components/providers/DomainsProviders.kt
+++ b/src/main/kotlin/io/github/mbalatsko/emailverifier/components/providers/DomainsProviders.kt
@@ -4,6 +4,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import org.slf4j.LoggerFactory
+import java.io.File
 import java.net.IDN
 
 /**
@@ -90,7 +91,7 @@ class OnlineLFDomainsProvider(
  *
  * @property resourcesFilePath the path to the linefeed-separated domain list within the resources.
  */
-class OfflineLFDomainsProvider(
+class ResourceFileLFDomainsProvider(
     private val resourcesFilePath: String,
 ) : LFDomainsProvider() {
     private val resourceUrl = this.javaClass.getResource(resourcesFilePath)
@@ -112,6 +113,33 @@ class OfflineLFDomainsProvider(
     }
 
     companion object {
-        private val logger = LoggerFactory.getLogger(OfflineLFDomainsProvider::class.java)
+        private val logger = LoggerFactory.getLogger(ResourceFileLFDomainsProvider::class.java)
+    }
+}
+
+/**
+ * [LFDomainsProvider] implementation that retrieves domain data from a file on the local filesystem.
+ *
+ * @param filePath the path to the linefeed-separated domain list on the filesystem.
+ */
+class FileLFDomainsProvider(
+    filePath: String,
+) : LFDomainsProvider() {
+    private val file = File(filePath)
+
+    init {
+        require(file.exists()) { "$filePath does not exist" }
+        require(file.isFile) { "$filePath must be normal file" }
+    }
+
+    override suspend fun obtainData(): String {
+        logger.debug("Loading domains from file: {}", file.path)
+        val data = file.readText()
+        logger.debug("Successfully loaded {} bytes from {}", data.length, file.path)
+        return data
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(FileLFDomainsProvider::class.java)
     }
 }

--- a/src/test/kotlin/io/github/mbalatsko/emailverifier/EmailVerifierTest.kt
+++ b/src/test/kotlin/io/github/mbalatsko/emailverifier/EmailVerifierTest.kt
@@ -1,5 +1,6 @@
 package io.github.mbalatsko.emailverifier
 
+import io.github.mbalatsko.emailverifier.components.Constants
 import io.github.mbalatsko.emailverifier.components.checkers.EmailSyntaxChecker
 import io.github.mbalatsko.emailverifier.components.checkers.HostnameInDatasetChecker
 import io.github.mbalatsko.emailverifier.components.checkers.MxRecord
@@ -12,6 +13,9 @@ import io.github.mbalatsko.emailverifier.components.core.DnsLookupBackend
 import io.github.mbalatsko.emailverifier.components.providers.DomainsProvider
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createTempFile
+import kotlin.io.path.deleteExisting
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -189,6 +193,100 @@ class EmailVerifierLocalTest {
             assertTrue(result.disposable is CheckResult.Skipped)
             assertTrue(result.free is CheckResult.Skipped)
             assertTrue(result.isLikelyDeliverable())
+        }
+
+    @Test
+    fun `throws for improper configuration - both resourcesFilePath and filePath are null`() =
+        runTest {
+            kotlin.test.assertFailsWith<IllegalArgumentException> {
+                emailVerifier {
+                    registrability {
+                        offline = true
+                        resourcesFilePath = null
+                        filePath = null
+                    }
+                }
+            }
+
+            kotlin.test.assertFailsWith<IllegalArgumentException> {
+                emailVerifier {
+                    free {
+                        offline = true
+                        resourcesFilePath = null
+                        filePath = null
+                    }
+                }
+            }
+
+            kotlin.test.assertFailsWith<IllegalArgumentException> {
+                emailVerifier {
+                    disposability {
+                        offline = true
+                        resourcesFilePath = null
+                        filePath = null
+                    }
+                }
+            }
+
+            kotlin.test.assertFailsWith<IllegalArgumentException> {
+                emailVerifier {
+                    roleBasedUsername {
+                        offline = true
+                        resourcesFilePath = null
+                        filePath = null
+                    }
+                }
+            }
+        }
+
+    @Test
+    fun `throws for improper configuration - both resourcesFilePath and filePath are set`() =
+        runTest {
+            // ensure input file exists
+            val tempFile = createTempFile(prefix = "domains", suffix = ".txt")
+
+            kotlin.test.assertFailsWith<IllegalArgumentException> {
+                emailVerifier {
+                    registrability {
+                        offline = true
+                        resourcesFilePath = RegistrabilityChecker.MOZILLA_PSL_RESOURCE_FILE
+                        filePath = tempFile.absolutePathString()
+                    }
+                }
+            }
+
+            kotlin.test.assertFailsWith<IllegalArgumentException> {
+                emailVerifier {
+                    free {
+                        offline = true
+                        resourcesFilePath = Constants.FREE_EMAILS_LIST_RESOURCE_FILE
+                        filePath = tempFile.absolutePathString()
+                    }
+                }
+            }
+
+            kotlin.test.assertFailsWith<IllegalArgumentException> {
+                emailVerifier {
+                    disposability {
+                        offline = true
+                        resourcesFilePath = Constants.DISPOSABLE_EMAILS_LIST_STRICT_RESOURCE_FILE
+                        filePath = tempFile.absolutePathString()
+                    }
+                }
+            }
+
+            kotlin.test.assertFailsWith<IllegalArgumentException> {
+                emailVerifier {
+                    roleBasedUsername {
+                        offline = true
+                        resourcesFilePath = Constants.ROLE_BASED_USERNAMES_LIST_RESOURCE_FILE
+                        filePath = tempFile.absolutePathString()
+                    }
+                }
+            }
+
+            // cleanup
+            tempFile.deleteExisting()
         }
 }
 

--- a/src/test/kotlin/io/github/mbalatsko/emailverifier/components/providers/DomainProvidersTest.kt
+++ b/src/test/kotlin/io/github/mbalatsko/emailverifier/components/providers/DomainProvidersTest.kt
@@ -5,6 +5,10 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.http.headersOf
 import kotlinx.coroutines.test.runTest
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.createTempFile
+import kotlin.io.path.deleteExisting
+import kotlin.io.path.writeText
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -67,18 +71,39 @@ class DomainProvidersTest {
         }
 
     @Test
-    fun `offline provider returns expected data`() =
+    fun `resource file provider returns expected data`() =
         runTest {
-            val provider = OfflineLFDomainsProvider("/offline-data/disposable.txt")
+            val provider = ResourceFileLFDomainsProvider("/test.txt")
             val result = provider.provide()
             assertTrue(result.contains("yopmail.com"))
             assertTrue(result.contains("simplelogin.com"))
         }
 
     @Test
-    fun `offline provider throws for non-existent resource`() {
+    fun `resource file provider throws for non-existent resource`() {
         kotlin.test.assertFailsWith<IllegalArgumentException> {
-            OfflineLFDomainsProvider("non-existent-file.txt")
+            ResourceFileLFDomainsProvider("non-existent-file.txt")
+        }
+    }
+
+    @Test
+    fun `file provider returns expected data`() =
+        runTest {
+            val tempFile = createTempFile(prefix = "domains", suffix = ".txt")
+            tempFile.writeText("domain.com")
+
+            val provider = FileLFDomainsProvider(tempFile.absolutePathString())
+            val result = provider.provide()
+            assertTrue(result.contains("domain.com"))
+
+            // cleanup
+            tempFile.deleteExisting()
+        }
+
+    @Test
+    fun `file file provider throws for non-existent resource`() {
+        kotlin.test.assertFailsWith<IllegalArgumentException> {
+            FileLFDomainsProvider("/non-existent-file.txt")
         }
     }
 }

--- a/src/test/resources/test.txt
+++ b/src/test/resources/test.txt
@@ -1,0 +1,2 @@
+yopmail.com
+simplelogin.com


### PR DESCRIPTION
Allow users to provide their own data files from the local filesystem or classpath resources for dataset-based checks (Registrability, Disposability, Free, Role-Based).
- Add filePath and resourcesFilePath properties to configuration builders.
- Implement FileLFDomainsProvider and rename OfflineLFDomainsProvider to ResourceFileLFDomainsProvider for clarity.