### PR TITLE
feat: Add dynamic data reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,31 @@ The `emailVerifier {}` call performs several network requests to download the ne
 To avoid re-downloading this data every time you want to verify an email, it is highly recommended to **create a single
 instance of the `EmailVerifier` and reuse it throughout the lifecycle of your application**.
 
-## 7. Logging
+### 7. Dynamic Data Reloading
+
+For long-running applications, it's often necessary to refresh the data used by the verifier without restarting the application.
+`EmailVerifier` provides a set of `suspend` functions to reload the data for the checks that use external datasets.
+
+These functions are thread-safe and will fetch the latest data from the configured `DataSource` (remote, file, or resource).
+
+```kotlin
+val verifier = emailVerifier {
+    // Your configuration...
+}
+
+// Refresh the Public Suffix List data
+verifier.updateRegistrabilityCheckerData()
+
+// Refresh the disposable email domains data
+verifier.updateDisposableCheckerData()
+
+// Refresh all data sources in parallel
+verifier.updateAllData()
+```
+
+This is particularly useful if you want to keep your disposable email lists or other datasets up-to-date by periodically calling these methods.
+
+## 8. Logging
 
 `EmailVerifier` uses the [SLF4J](https://www.slf4j.org/) logging facade. This allows you, as a user of the library, to choose your own logging framework (e.g., [Logback](http://logback.qos.ch/), [Log4j 2](https://logging.apache.org/log4j/2.x/), `slf4j-simple`). The library itself only includes the `slf4j-api` dependency, so it does not force a specific logging implementation on your application.
 

--- a/src/main/kotlin/io/github/mbalatsko/emailverifier/components/checkers/IChecker.kt
+++ b/src/main/kotlin/io/github/mbalatsko/emailverifier/components/checkers/IChecker.kt
@@ -21,3 +21,15 @@ interface IChecker<out Output, in Context> {
         context: Context,
     ): Output
 }
+
+/**
+ * An interface for components that can have their data refreshed at runtime.
+ * This is useful for long-running applications that need to keep their data up-to-date.
+ */
+interface Refreshable {
+    /**
+     * Refreshes the data from the underlying data source.
+     * This operation is expected to be thread-safe.
+     */
+    suspend fun refresh()
+}

--- a/src/main/kotlin/io/github/mbalatsko/emailverifier/components/providers/DomainsProviders.kt
+++ b/src/main/kotlin/io/github/mbalatsko/emailverifier/components/providers/DomainsProviders.kt
@@ -1,5 +1,6 @@
 package io.github.mbalatsko.emailverifier.components.providers
 
+import io.github.mbalatsko.emailverifier.components.core.ConnectionError
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
@@ -65,19 +66,13 @@ class OnlineLFDomainsProvider(
      */
     override suspend fun obtainData(): String {
         logger.debug("Fetching domains from URL: {}", url)
-        return try {
-            val response = httpClient.get(url)
-            if (response.status.value >= 400) {
-                logger.warn("Failed to fetch domains from {}: HTTP status {}", url, response.status)
-                ""
-            } else {
-                val data = response.bodyAsText()
-                logger.debug("Successfully fetched {} bytes from {}", data.length, url)
-                data
-            }
-        } catch (e: Exception) {
-            logger.error("Error fetching domains from {}", url, e)
-            ""
+        val response = httpClient.get(url)
+        if (response.status.value >= 400) {
+            throw ConnectionError("Failed to fetch domains from $url: HTTP status ${response.status}")
+        } else {
+            val data = response.bodyAsText()
+            logger.debug("Successfully fetched {} bytes from {}", data.length, url)
+            return data
         }
     }
 

--- a/src/test/kotlin/io/github/mbalatsko/emailverifier/EmailVerifierDataUpdateTest.kt
+++ b/src/test/kotlin/io/github/mbalatsko/emailverifier/EmailVerifierDataUpdateTest.kt
@@ -1,0 +1,76 @@
+package io.github.mbalatsko.emailverifier
+
+import io.github.mbalatsko.emailverifier.components.checkers.HostnameInDatasetChecker
+import io.github.mbalatsko.emailverifier.components.checkers.RegistrabilityChecker
+import io.github.mbalatsko.emailverifier.components.checkers.UsernameInDatasetChecker
+import io.github.mbalatsko.emailverifier.components.core.CheckResult
+import io.github.mbalatsko.emailverifier.components.providers.DomainsProvider
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class EmailVerifierDataUpdateTest {
+    private class MutableSetProvider(
+        private var items: Set<String>,
+    ) : DomainsProvider {
+        override suspend fun provide(): Set<String> = items
+
+        fun add(item: String) {
+            items = items + item
+        }
+    }
+
+    @Test
+    fun `updateAllData refreshes all checkers`() =
+        runTest {
+            val pslProvider = MutableSetProvider(setOf("com"))
+            val disposableProvider = MutableSetProvider(setOf("disposable.com"))
+            val freeProvider = MutableSetProvider(setOf("free.com"))
+            val roleBasedProvider = MutableSetProvider(setOf("role"))
+
+            val verifier =
+                EmailVerifier(
+                    emailSyntaxChecker =
+                        io.github.mbalatsko.emailverifier.components.checkers
+                            .EmailSyntaxChecker(),
+                    registrabilityChecker = RegistrabilityChecker.create(pslProvider),
+                    mxRecordChecker = null,
+                    disposableEmailChecker = HostnameInDatasetChecker.create(disposableProvider, emptySet(), emptySet()),
+                    gravatarChecker = null,
+                    freeChecker = HostnameInDatasetChecker.create(freeProvider, emptySet(), emptySet()),
+                    roleBasedUsernameChecker = UsernameInDatasetChecker.create(roleBasedProvider, emptySet(), emptySet()),
+                    smtpChecker = null,
+                )
+
+            var result = verifier.verify("user@newdisposable.com")
+            assertIs<CheckResult.Passed<*>>(result.disposable)
+
+            result = verifier.verify("user@newfree.com")
+            assertIs<CheckResult.Passed<*>>(result.free)
+
+            result = verifier.verify("newrole@example.com")
+            assertIs<CheckResult.Passed<*>>(result.roleBasedUsername)
+
+            result = verifier.verify("user@something.newtld")
+            assertIs<CheckResult.Failed<*>>(result.registrability)
+
+            pslProvider.add("newtld")
+            disposableProvider.add("newdisposable.com")
+            freeProvider.add("newfree.com")
+            roleBasedProvider.add("newrole")
+
+            verifier.updateAllData()
+
+            result = verifier.verify("user@newdisposable.com")
+            assertIs<CheckResult.Failed<*>>(result.disposable)
+
+            result = verifier.verify("user@newfree.com")
+            assertIs<CheckResult.Failed<*>>(result.free)
+
+            result = verifier.verify("newrole@example.com")
+            assertIs<CheckResult.Failed<*>>(result.roleBasedUsername)
+
+            result = verifier.verify("user@something.newtld")
+            assertIs<CheckResult.Passed<*>>(result.registrability)
+        }
+}


### PR DESCRIPTION
This PR introduces the ability to dynamically reload the data used by the verifier at runtime. This is particularly useful for long-running applications that need to keep their datasets (e.g., disposable domains, public suffix list) up-to-date without restarting.

Key changes:
- Added `updateAllData()` and individual `update<Checker>Data()` methods to `EmailVerifier` to trigger data refreshes.
- Introduced a `Refreshable` interface for components that support data reloading.
- Made `RegistrabilityChecker` and `DatasetCheckers` thread-safe and refreshable.
- Added a new test suite (`EmailVerifierDataUpdateTest`) to verify the data reloading functionality.