### PR TITLE
feat: Allow custom PSL rule configuration for registrability check

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,14 @@ val verifier = emailVerifier {
         enabled = false
     }
 
+    registrability {
+        customRules = setOf(
+          "my-private-tld",       // Treat .my-private-tld as a public suffix
+          "*.my-private-domain",  // Treat all subdomains of .my-private-domain as public suffixes
+          "!example.my-private-domain" // Make an exception to the wildcard rule
+        )
+    }
+
     // Configure allow/deny lists for dataset checks
     disposability {
         allow = setOf("my-disposable-domain.com") // Whitelist a disposable domain

--- a/src/main/kotlin/io/github/mbalatsko/emailverifier/EmailVerifierDsl.kt
+++ b/src/main/kotlin/io/github/mbalatsko/emailverifier/EmailVerifierDsl.kt
@@ -48,10 +48,12 @@ sealed interface DataSource {
  *
  * @property enabled whether this check should be performed.
  * @property source The data source for the PSL data.
+ * @property customRules A set of custom PSL rules.
  */
 data class RegistrabilityConfig(
     val enabled: Boolean,
     val source: DataSource,
+    val customRules: Set<String>,
 )
 
 /**
@@ -80,7 +82,10 @@ class RegistrabilityConfigBuilder {
                 }
         }
 
-    internal fun build() = RegistrabilityConfig(enabled, source)
+    /** A set of custom PSL rules. */
+    var customRules: Set<String> = emptySet()
+
+    internal fun build() = RegistrabilityConfig(enabled, source, customRules)
 }
 
 /**
@@ -468,7 +473,7 @@ class EmailVerifierDslBuilder {
     ) = if (config.enabled) {
         logger.debug("Creating RegistrabilityChecker...")
         val provider = createDomainsProvider(config.source, httpClient)
-        RegistrabilityChecker.create(provider)
+        RegistrabilityChecker.create(provider, config.customRules)
     } else {
         logger.debug("RegistrabilityChecker is disabled.")
         null


### PR DESCRIPTION
This change introduces the ability for users to provide a set of custom Public Suffix List (PSL) rules directly in the configuration. This is useful for applications that need to handle private top-level domains (TLDs) or want to override specific rules from the main PSL data source without having to host a custom version of the entire list.

The registrability configuration block now includes a customRules property, which accepts a Set<String> of PSL rules.